### PR TITLE
bump equate

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -1,7 +1,7 @@
 // global
 #import "@preview/great-theorems:0.1.2": great-theorems-init
 #import "@preview/hydra:0.5.2": hydra
-#import "@preview/equate:0.3.0": equate
+#import "@preview/equate:0.3.1": equate
 #import "@preview/i-figured:0.2.4": reset-counters, show-equation
 
 #let template(


### PR DESCRIPTION
equate on v.0.3.1 now in this repo as well (was 0.3.0 before, which caused some problems with typst 0.13)