### PR TITLE
Add frontmatter, automatically hide list of figures, better page numbering, section numbering in PDF outline

### DIFF
--- a/hacks.typ
+++ b/hacks.typ
@@ -1,0 +1,36 @@
+// Hack: adds heading numbering into PDF bookmark outlines
+// Taken from: https://forum.typst.app/t/how-to-display-chapter-numbers-in-pdf-bookmarks/4912/4
+// Github issue, might get fixed eventually:
+// https://github.com/typst/typst/issues/2416#issue-1947070361
+
+// this code snippet must be placed AFTER styling (eg. chapters) so link points to above the heading
+// and BEFORE page/line breaks so link points to after the page/line breaks.
+#let bookmark-numbering-hack(it) = {
+  set heading(bookmarked: false)
+  show heading: it => if it.numbering == none {
+    // This heading has been processed. Keep it untouched.
+    it
+  } else {
+    let (numbering, body, ..args) = it.fields()
+    let _ = args.remove("label", default: none)
+
+    // Render the numbering manually
+    let numbered-body = block({
+      counter(heading).display(numbering)
+      [ ] // space in the bookmark
+      body
+    })
+
+    // Add our bookmarked, hidden heading
+    {
+      show heading: none
+      heading(..args, outlined: false, bookmarked: true, numbering: none,
+        numbered-body)
+    }
+
+    // regular heading
+    it
+
+  }
+  it
+}

--- a/headings.typ
+++ b/headings.typ
@@ -1,0 +1,92 @@
+// Heading settings.
+// In a thesis we want
+// - Level 1 headings to be called Chapters [heading1-as-chapter]
+// - PDF bookmark to contain heading numberings 1.1.2 etc [hacks.typ: bookmark-numbering-hack]
+// - Chapters to start on a new page [break-before-headings]
+
+// They must be created in the precise order above, so the PDF link points to directly
+// ABOVE the cosmetics and BELOW the breaks.
+
+#import "hacks.typ": bookmark-numbering-hack
+
+// prepend breaks before headings
+#let break-before-headings(it) = {
+  // Automatically insert a page break before each chapter
+  show heading.where(
+    level: 1
+  ): it => {
+    pagebreak(weak: true)
+    it
+  }
+  // only valid for abstract and declaration
+  show heading.where(
+    outlined: false,
+    level: 2
+  ): it => {
+    set align(center)
+    set text(18pt)
+    it.body
+    v(0.5cm, weak: true)
+  }
+  // Settings for sub-sub-sub-sections e.g. section 1.1.1.1
+  show heading.where(
+    level: 4
+  ): it => {
+    it.body
+    linebreak()
+  }
+  // same for level 5 headings
+  show heading.where(
+    level: 5
+  ): it => {
+    it.body
+    linebreak()
+  }
+  it
+}
+
+// stylizes level 1 headings
+#let heading1-as-chapter(heading-color, it) = {
+  // ------------------- Settings for Chapter headings -------------------
+  show heading.where(level: 1): set heading(supplement: [Chapter])
+  show heading.where(
+    level: 1,
+  ): it => {
+    if it.numbering != none {
+      block(width: 100%)[
+        #line(length: 100%, stroke: 0.6pt + heading-color)
+        #v(0.1cm)
+        #set align(left)
+        #set text(22pt)
+        #text(heading-color)[Chapter
+        #counter(heading).display(
+          "1:" + it.numbering
+        )]
+
+        #it.body
+        #v(-0.5cm)
+        #line(length: 100%, stroke: 0.6pt + heading-color)
+      ]
+    }
+    else {
+      block(width: 100%)[
+        #line(length: 100%, stroke: 0.6pt + heading-color)
+        #v(0.1cm)
+        #set align(left)
+        #set text(22pt)
+        #it.body
+        #v(-0.5cm)
+        #line(length: 100%, stroke: 0.6pt + heading-color)
+      ]
+    }
+  }
+  it
+}
+
+#let thesis-heading(heading-color, it) = {
+  // DO NOT CHANGE THE ORDER
+  show: it => heading1-as-chapter(heading-color, it)
+  show: bookmark-numbering-hack
+  show: break-before-headings
+  it
+}

--- a/lib.typ
+++ b/lib.typ
@@ -27,6 +27,9 @@
   cover-font: "Libertinus Serif",
 
   // content that needs to be placed differently then normal chapters
+  // frontmatter is put BEFORE the cover page
+  frontmatter: none,
+  // abstract is put AFTER cover, BEFORE outline
   abstract: none,
 
   // colors
@@ -102,6 +105,13 @@ show ref: it => {
 
 show math.equation: box  // no line breaks in inline math
 show: great-theorems-init  // show rules for theorems
+
+// --------------- Frontmatter ---------------
+// before the cover page, usually a university-given cover page
+set text(font: body-font)  // body font
+if frontmatter != none{
+  frontmatter
+}
 
 
 // ------------------- Settings for Chapter headings -------------------

--- a/lib.typ
+++ b/lib.typ
@@ -50,6 +50,7 @@ set heading(numbering: "1.1")  // Heading numbering
 set enum(numbering: "(i)") // Enumerated lists
 show link: set text(fill: link-color)
 show ref: set text(fill: link-color)
+set page(numbering: "i'")
 
 // ------------------- Math equation settings -------------------
 
@@ -201,7 +202,11 @@ show figure.where(
   kind: table
 ): set figure.caption(position: top)
 
+
+set page(numbering: "i")
+counter(page).update(1)
 // ------------------- Cover -------------------
+set page(footer: none) // disable footer until the end of contents
 set text(font: cover-font)  // cover font
 
 v(1fr)
@@ -299,14 +304,6 @@ if abstract != none{
 }
 
 
-set page(
-  numbering: "1",
-  number-align: center,
-  header: context {
-    align(center, emph(hydra(1)))
-    v(0.2cm)
-  },
-)  // Page numbering after cover & abstract => they have no page number
 pagebreak()
 
 // ------------------- Tables of ... -------------------
@@ -337,6 +334,18 @@ context {
     pagebreak()
   }
 }
+
+// Re-enable page numbering before content
+set page(
+  numbering: "1",
+  number-align: center,
+  header: context {
+    align(center, emph(hydra(1)))
+    v(0.2cm)
+  },
+  footer: auto
+)
+counter(page).update(1)
 
 // ------------------- Content -------------------
 body

--- a/lib.typ
+++ b/lib.typ
@@ -316,22 +316,27 @@ set outline.entry(fill: line(length: 100%, stroke: (thickness: 1pt, dash: "loose
 outline(depth: 3, indent: 1em)
 pagebreak()
 
-// List of figures
-outline(
-  title: [List of Figures],
-  target: figure.where(kind: image)
-)
-pagebreak()
+context {
+  // List of figures
+  let figures = figure.where(kind: image)
+  if query(figures).len() > 0 {
+    outline(
+      title: [List of Figures],
+      target: figures,
+    )
+    pagebreak()
+  }
 
-
-// List of Tables
-outline(
-  title: [List of Tables],
-  target: figure.where(kind: table)
-)
-pagebreak()
-
-
+  // List of Tables
+  let tables = figure.where(kind: table)
+  if query(tables).len() > 0 {
+    outline(
+      title: [List of Tables],
+      target: tables
+    )
+    pagebreak()
+  }
+}
 
 // ------------------- Content -------------------
 body

--- a/lib.typ
+++ b/lib.typ
@@ -4,6 +4,8 @@
 #import "@preview/equate:0.3.1": equate
 #import "@preview/i-figured:0.2.4": reset-counters, show-equation
 
+#import "headings.typ": thesis-heading
+
 #let template(
   // personal/subject related stuff
   author: "Stuart Dent",
@@ -116,69 +118,7 @@ if frontmatter != none{
 
 
 // ------------------- Settings for Chapter headings -------------------
-show heading.where(level: 1): set heading(supplement: [Chapter])
-show heading.where(
-  level: 1,
-): it => {
-  if it.numbering != none {
-    block(width: 100%)[
-      #line(length: 100%, stroke: 0.6pt + heading-color)
-      #v(0.1cm)
-      #set align(left)
-      #set text(22pt)
-      #text(heading-color)[Chapter
-      #counter(heading).display(
-        "1:" + it.numbering
-      )]
-
-      #it.body
-      #v(-0.5cm)
-      #line(length: 100%, stroke: 0.6pt + heading-color)
-    ]
-  }
-  else {
-    block(width: 100%)[
-      #line(length: 100%, stroke: 0.6pt + heading-color)
-      #v(0.1cm)
-      #set align(left)
-      #set text(22pt)
-      #it.body
-      #v(-0.5cm)
-      #line(length: 100%, stroke: 0.6pt + heading-color)
-    ]
-  }
-}
-// Automatically insert a page break before each chapter
-show heading.where(
-  level: 1
-): it => {
-  pagebreak(weak: true)
-  it
-}
-// only valid for abstract and declaration
-show heading.where(
-  outlined: false,
-  level: 2
-): it => {
-  set align(center)
-  set text(18pt)
-  it.body
-  v(0.5cm, weak: true)
-}
-// Settings for sub-sub-sub-sections e.g. section 1.1.1.1
-show heading.where(
-  level: 4
-): it => {
-  it.body
-  linebreak()
-}
-// same for level 5 headings
-show heading.where(
-  level: 5
-): it => {
-  it.body
-  linebreak()
-}
+show: it => thesis-heading(heading-color, it)
 
 // reset counter from i-figured for section-based equation numbering
 show heading: it => {


### PR DESCRIPTION
I have made a few handy (but perhaps a little opinionated) changes that might be of use to others, therefore I open this pull request. Even if it is not merged in the end, some might find it useful :) 

+ [feat: add frontmatter](https://github.com/sebaseb98/clean-math-thesis/commit/3fac9492df2a4465c1aa30663e4139e49976c22e)

  frontmatter is content placed before the cover page.

+ [feat: show list of figures/tables only if non-empty](https://github.com/sebaseb98/clean-math-thesis/commit/9ce77099fd3aeff57de8d14cbb71837be2b7687f)

+ [feat: better page numbering](https://github.com/sebaseb98/clean-math-thesis/commit/41c860edd49cb829e8a0f6f689fcbd39084ad613)

  Before this commit, page numbers are arabic (1, 2, ...) throughout,
  and unavailable to PDF metadata when hidden (e.g. at the cover page).
  
  This commit adds page numbering as below:
  - frontmatter (before cover) gets (i', ii', ...)
  - cover page (before actual content) gets (i, ii, ...)
  - actual content gets (1, 2, ...)
  
  and all numberings are present in PDF metadata.

+ [feat: add section numbering to PDF bookmark outline](https://github.com/sebaseb98/clean-math-thesis/commit/2e7bf9c8c9d78c504cb6c2d47b89f1307ff3c7e5)

  As of Typst 0.13.1, there is no section numbering in PDF bookmarks.
  The way to work around this is to hide the actual heading from the
  bookmarks, and create an invisible, bookmarked heading with prepended
  numberings just above it.
  
  These invisible headings are placed before the visible, actual headings
  BUT after the pre-heading page/line breaks for accurate PDF link redirection.
  
  All these are refactored into two files, hacks.typ and headings.typ
  for easy management.