### PR TITLE
Do not pagebreak when no asbtract is provided

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -242,12 +242,11 @@ show heading: it => {
 
 // ------------------- Abstract -------------------
 set text(font: body-font)  // body font
-if abstract != none{
+
+if abstract != none {
   abstract
+  pagebreak()
 }
-
-
-pagebreak()
 
 // ------------------- Tables of ... -------------------
 


### PR DESCRIPTION
Conveniently the template checks that abstract is supplied before trying to apply the parameter.   
However it adds a `pagebreak()` anyway, rendering a blank page if no abstract is provided.

I could agree that this is a rather rare circumstance, however adding a blank page has no particular benefit and the behavior can still be reproduced with the change I suggest.